### PR TITLE
7.1.1 Bugfix release

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,8 +3,6 @@ name: PHPUnit Tests
 on:
   push:
     branches: [ "**" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Release [v7.1.1](https://github.com/sweikenb/pcntl/releases/tag/v7.1.1)
+
+**Bugfixes**
+
+- Set proper exit-code `130` when the `SIGINT`-signal is received
+
+* * *
+
 ## Release [v7.1.0](https://github.com/sweikenb/pcntl/releases/tag/v7.1.0)
 
 **Features**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -104,6 +104,9 @@ class ProcessManager implements ProcessManagerInterface
         } else {
             $this->sendSignalToChildren($signal);
         }
+        if ($signal === SIGINT) {
+            exit(130); // ctrl + c
+        }
     }
 
     public function sendSignalToChildren(int $signal, ?callable $callback = null): void


### PR DESCRIPTION
**Bugfixes**

- Set proper exit-code `130` when the `SIGINT`-signal is received